### PR TITLE
Add npm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ not `require()`.
 import allNodeVersions from 'all-node-versions'
 
 const printNodeVersions = async function (options) {
-  const { versions, majors } = await allNodeVersions(options)
+  const { versions, majors, nodeNpmVersion } = await allNodeVersions(options)
 
   console.log(versions)
   // ['16.3.0', '16.2.0', ..., '0.1.15', '0.1.14']
@@ -48,6 +48,23 @@ const printNodeVersions = async function (options) {
   //   { major: 5, latest: '5.12.0' },
   //   { major: 4, latest: '4.9.1', lts: 'argon' },
   //   { major: 0, latest: '0.12.18' }
+  // ]
+
+  console.log(nodeNpmVersion)
+  // [
+  //   { node: '18.4.0', npm: '8.12.1' },
+  //   { node: '18.3.0', npm: '8.11.0' },
+  //   { node: '18.2.0', npm: '8.9.0' },
+  //   { node: '18.1.0', npm: '8.8.0' },
+  //   { node: '18.0.0', npm: '8.6.0' },
+  //   { node: '17.9.1', npm: '8.11.0' },
+  //   { node: '17.9.0', npm: '8.5.5' },
+  //   { node: '17.8.0', npm: '8.5.5' },
+  //   { node: '17.7.2', npm: '8.5.2' },
+  //   { node: '17.7.1', npm: '8.5.2' },
+  //   { node: '17.7.0', npm: '8.5.2' },
+  //   { node: '17.6.0', npm: '8.5.1' },
+  //   ...
   // ]
 }
 ```
@@ -92,6 +109,25 @@ Latest version for that major release, as a `major.minor.patch` string.
 _Type_: `string?`
 
 LTS name, lowercased. `undefined` if the major release is not LTS.
+
+#### nodeNpmVersion
+
+_Type_: `object[]`
+
+List of available Node.js versions and default NPM versions sorted from the most
+to the least recent Node.js version.
+
+##### node
+
+_Type_: `string`
+
+Node.js version is a `major.minor.patch` string.
+
+##### npm
+
+_Type_: `string`
+
+NPM version is a raw version value: can be 6.5.0-next.0, for example.
 
 ### options
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Node.js version is a `major.minor.patch` string.
 
 _Type_: `string?`
 
-NPM version is a raw version value: can be `"6.5.0-next.0"`, for example.
-`undefined` for ancient node that didn't ship with npm.
+Default NPM version is a raw version value: can be `"6.5.0-next.0"`, for
+example. `undefined` for ancient node that didn't ship with npm.
 
 #### majors
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,21 @@ import allNodeVersions from 'all-node-versions'
 
 const {
   versions,
-  // ['18.4.0', '18.3.0', ..., '0.1.15', '0.1.14']
+  // [
+  //   { node: '18.4.0', npm: '8.12.1' },
+  //   { node: '18.3.0', npm: '8.11.0' },
+  //   { node: '18.2.0', npm: '8.9.0' },
+  //   { node: '18.1.0', npm: '8.8.0' },
+  //   { node: '18.0.0', npm: '8.6.0' },
+  //   { node: '17.9.1', npm: '8.11.0' },
+  //   { node: '17.9.0', npm: '8.5.5' },
+  //   { node: '17.8.0', npm: '8.5.5' },
+  //   { node: '17.7.2', npm: '8.5.2' },
+  //   { node: '17.7.1', npm: '8.5.2' },
+  //   { node: '17.7.0', npm: '8.5.2' },
+  //   { node: '17.6.0', npm: '8.5.1' },
+  //   ...
+  // ]
   majors,
   // [
   //   { major: 18, latest: '18.4.0' },
@@ -48,22 +62,6 @@ const {
   //   { major: 4, latest: '4.9.1', lts: 'argon' },
   //   { major: 0, latest: '0.12.18' }
   // ]
-  nodeNpmVersions,
-  // [
-  //   { node: '18.4.0', npm: '8.12.1' },
-  //   { node: '18.3.0', npm: '8.11.0' },
-  //   { node: '18.2.0', npm: '8.9.0' },
-  //   { node: '18.1.0', npm: '8.8.0' },
-  //   { node: '18.0.0', npm: '8.6.0' },
-  //   { node: '17.9.1', npm: '8.11.0' },
-  //   { node: '17.9.0', npm: '8.5.5' },
-  //   { node: '17.8.0', npm: '8.5.5' },
-  //   { node: '17.7.2', npm: '8.5.2' },
-  //   { node: '17.7.1', npm: '8.5.2' },
-  //   { node: '17.7.0', npm: '8.5.2' },
-  //   { node: '17.6.0', npm: '8.5.1' },
-  //   ...
-  // ]
 } = await allNodeVersions(options)
 ```
 
@@ -78,10 +76,23 @@ The return value resolves to an object with the following properties.
 
 #### versions
 
-_Type_: `string[]`
+_Type_: `object[]`
 
-List of available Node.js versions sorted from the most to the least recent.
-Each version is a `major.minor.patch` string.
+List of available Node.js versions and default NPM versions sorted from the most
+to the least recent Node.js version.
+
+##### node
+
+_Type_: `string`
+
+Node.js version is a `major.minor.patch` string.
+
+##### npm
+
+_Type_: `string?`
+
+NPM version is a raw version value: can be `"6.5.0-next.0"`, for example.
+`undefined` for ancient node that didn't ship with npm.
 
 #### majors
 
@@ -107,26 +118,6 @@ Latest version for that major release, as a `major.minor.patch` string.
 _Type_: `string?`
 
 LTS name, lowercased. `undefined` if the major release is not LTS.
-
-#### nodeNpmVersions
-
-_Type_: `object[]`
-
-List of available Node.js versions and default NPM versions sorted from the most
-to the least recent Node.js version.
-
-##### node
-
-_Type_: `string`
-
-Node.js version is a `major.minor.patch` string.
-
-##### npm
-
-_Type_: `string`
-
-NPM version is a raw version value: can be 6.5.0-next.0, for example. Will be
-0.0.0 for ancient node that didn't ship with npm.
 
 ### options
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Node.js version is a `major.minor.patch` string.
 
 _Type_: `string`
 
-NPM version is a raw version value: can be 6.5.0-next.0, for example.
+NPM version is a raw version value: can be 6.5.0-next.0, for example. Will be
+0.0.0 for ancient node that didn't ship with npm.
 
 ### options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "all-node-versions",
-  "version": "10.1.1",
+  "version": "11.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "all-node-versions",
-      "version": "10.1.1",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fetch-node-website": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-node-versions",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "type": "module",
   "exports": "./build/src/main.js",
   "main": "./build/src/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-node-versions",
-  "version": "10.2.0",
+  "version": "11.0.0",
   "type": "module",
   "exports": "./build/src/main.js",
   "main": "./build/src/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-node-versions",
-  "version": "11.0.0",
+  "version": "10.1.1",
   "type": "module",
   "exports": "./build/src/main.js",
   "main": "./build/src/main.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "examples/**/*.{js,d.ts,map,json,sh,md}"
   ],
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test && tsd"
   },
   "description": "List all available Node.js versions",
   "keywords": [

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -5,7 +5,20 @@ import type { Options as FetchNodeWebsiteOptions } from 'fetch-node-website'
  */
 export type SemverVersion = `${number}.${number}.${number}${string}`
 
-export interface MajorNodeVersions {
+export interface NodeVersionInfo {
+  /**
+   * Node.js version is a `major.minor.patch` string.
+   */
+  node: SemverVersion
+
+  /**
+   * Default NPM version is a raw version value: can be `"6.5.0-next.0"`, for example.
+   * `undefined` for ancient node that didn't ship with npm.
+   */
+  npm?: SemverVersion
+}
+
+export interface MajorNodeVersion {
   /**
    * Major version number. `0` for old releases `0.*.*`.
    */
@@ -22,17 +35,16 @@ export interface MajorNodeVersions {
   lts?: string
 }
 
-export interface NodeVersions {
+export interface NodeVersion {
   /**
-   * List of available Node.js versions sorted from the most to the least
-   * recent. Each version is a `major.minor.patch` string.
+   * List of available Node.js versions and default NPM versions sorted from the most to the least recent Node.js version.
    */
-  versions: SemverVersion[]
+  versions: NodeVersionInfo[]
 
   /**
    * List of Node.js major releases sorted from the most to the least recent.
    */
-  majors: MajorNodeVersions[]
+  majors: MajorNodeVersion[]
 }
 
 export interface Options {
@@ -53,7 +65,7 @@ export interface Options {
    *  - `true`: the cache will not be used
    *  - `false`: the cache will be used even if it's older than one hour
    *
-   * @default `undefined``
+   * @default `undefined`
    */
   fetch?: boolean | undefined
 }
@@ -92,4 +104,4 @@ export interface Options {
  */
 export default function allNodeVersions(
   options?: Options,
-): Promise<NodeVersions>
+): Promise<NodeVersion>

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -35,7 +35,7 @@ export interface MajorNodeVersion {
   lts?: string
 }
 
-export interface NodeVersion {
+export interface AllNodeVersions {
   /**
    * List of available Node.js versions and default NPM versions sorted from the most to the least recent Node.js version.
    */
@@ -104,4 +104,4 @@ export interface Options {
  */
 export default function allNodeVersions(
   options?: Options,
-): Promise<NodeVersion>
+): Promise<AllNodeVersions>

--- a/src/main.test-d.ts
+++ b/src/main.test-d.ts
@@ -1,7 +1,7 @@
 import allNodeVersions, {
   Options,
-  NodeVersions,
-  MajorNodeVersions,
+  NodeVersion,
+  MajorNodeVersion,
   SemverVersion,
 } from 'all-node-versions'
 import {
@@ -10,6 +10,7 @@ import {
   expectAssignable,
   expectNotAssignable,
 } from 'tsd'
+import { NodeVersionInfo } from './main'
 
 const nodeVersions = await allNodeVersions()
 
@@ -26,18 +27,21 @@ allNodeVersions({ fetch: undefined })
 expectAssignable<Options>({ fetch: true })
 expectError(allNodeVersions({ fetch: 'true' }))
 
-expectType<NodeVersions>(nodeVersions)
+expectType<NodeVersion>(nodeVersions)
 const {
-  versions: [nodeVersion],
+  versions: [version],
   majors: [majorNodeVersion],
 } = nodeVersions
 
-expectAssignable<string>(nodeVersion)
+expectType<NodeVersionInfo>(version)
+const { node, npm } = version
+expectAssignable<SemverVersion>(node)
+expectType<SemverVersion | undefined>(npm)
 
-expectType<MajorNodeVersions>(majorNodeVersion)
+expectType<MajorNodeVersion>(majorNodeVersion)
 const { major, latest, lts } = majorNodeVersion
 expectType<number>(major)
-expectAssignable<string>(latest)
+expectAssignable<SemverVersion>(latest)
 expectType<string | undefined>(lts)
 
 expectAssignable<SemverVersion>('1.2.3')

--- a/src/main.test-d.ts
+++ b/src/main.test-d.ts
@@ -1,6 +1,6 @@
 import allNodeVersions, {
   Options,
-  NodeVersion,
+  AllNodeVersions,
   MajorNodeVersion,
   SemverVersion,
 } from 'all-node-versions'
@@ -27,7 +27,7 @@ allNodeVersions({ fetch: undefined })
 expectAssignable<Options>({ fetch: true })
 expectError(allNodeVersions({ fetch: 'true' }))
 
-expectType<NodeVersion>(nodeVersions)
+expectType<AllNodeVersions>(nodeVersions)
 const {
   versions: [version],
   majors: [majorNodeVersion],

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -7,14 +7,15 @@ export const normalizeIndex = function (index) {
   const indexItems = index.map(normalizeVersion)
   const versions = getAllVersions(indexItems)
   const majors = getMajors(indexItems)
-  return { versions, majors }
+  const nodeNpmVersions = getAllNodeNpmVersions(indexItems)
+  return { versions, majors, nodeNpmVersions }
 }
 
-const normalizeVersion = function ({ version, lts }) {
+const normalizeVersion = function ({ version, lts, npm }) {
   // Remove the leading `v`
   const versionA = version.slice(1)
   const major = semver.major(versionA)
-  return { version: versionA, major, lts }
+  return { version: versionA, major, lts, npm }
 }
 
 // Array with all version strings, sorted from most to least recent
@@ -24,6 +25,14 @@ const getAllVersions = function (indexItems) {
 
 const getVersionField = function ({ version }) {
   return version
+}
+
+// Array with all {node: ..., npm: ...} version pairs
+const getAllNodeNpmVersions = function (indexItems) {
+  return indexItems.map(({ version, npm }) => ({
+    node: version,
+    npm: npm || '0.0.0',
+  }))
 }
 
 // Array with all major releases latest version, sorted from most to least

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -7,8 +7,7 @@ export const normalizeIndex = function (index) {
   const indexItems = index.map(normalizeVersion)
   const versions = getAllVersions(indexItems)
   const majors = getMajors(indexItems)
-  const nodeNpmVersions = getAllNodeNpmVersions(indexItems)
-  return { versions, majors, nodeNpmVersions }
+  return { versions, majors }
 }
 
 const normalizeVersion = function ({ version, lts, npm }) {
@@ -18,20 +17,11 @@ const normalizeVersion = function ({ version, lts, npm }) {
   return { version: versionA, major, lts, npm }
 }
 
-// Array with all version strings, sorted from most to least recent
+// Array with all {node: string, npm: string} version infos
 const getAllVersions = function (indexItems) {
-  return indexItems.map(getVersionField)
-}
-
-const getVersionField = function ({ version }) {
-  return version
-}
-
-// Array with all {node: ..., npm: ...} version pairs
-const getAllNodeNpmVersions = function (indexItems) {
   return indexItems.map(({ version, npm }) => ({
     node: version,
-    npm: npm || '0.0.0',
+    npm,
   }))
 }
 

--- a/test/main.js
+++ b/test/main.js
@@ -7,7 +7,27 @@ const isVersion = function (version) {
   return typeof version === 'string' && VERSION_REGEXP.test(version)
 }
 
+const isNodeNpmVersion = function (nodeNpmVersion) {
+  return (
+    typeof nodeNpmVersion.node === 'string' &&
+    VERSION_REGEXP.test(nodeNpmVersion.node) &&
+    typeof nodeNpmVersion.npm === 'string' &&
+    NPM_VERSION_REGEXP.test(nodeNpmVersion.npm)
+  )
+}
+
 const VERSION_REGEXP = /^\d+\.\d+\.\d+$/u
+
+/**
+ * Real examples:
+ * 1.1.0-beta-4
+ * 1.1.0-alpha-6
+ * 1.1.18
+ * 6.5.0-next.0
+ * 1.1.0-3
+ */
+const NPM_VERSION_REGEXP =
+  /^\d+\.\d+\.\d+((-(alpha|beta)-\d+)|(-next\.\d+)|(-\d+))?$/u
 
 test('"versions" are present', async (t) => {
   const { versions } = await allNodeVersions({ fetch: true })
@@ -22,6 +42,23 @@ test('"versions" are sorted', async (t) => {
   const sortedVersions = [...versions].sort(semver.rcompare)
 
   t.deepEqual(versions, sortedVersions)
+})
+
+test('"nodeNpmVersions" are present', async (t) => {
+  const { nodeNpmVersions } = await allNodeVersions({ fetch: true })
+
+  t.true(Array.isArray(nodeNpmVersions))
+  t.true(nodeNpmVersions.every(isNodeNpmVersion))
+})
+
+test('"nodeNpmVersions" are sorted', async (t) => {
+  const { nodeNpmVersions } = await allNodeVersions({ fetch: true })
+  // eslint-disable-next-line fp/no-mutating-methods, id-length
+  const sortedVersions = [...nodeNpmVersions].sort((a, b) =>
+    semver.rcompare(a.node, b.node),
+  )
+
+  t.deepEqual(nodeNpmVersions, sortedVersions)
 })
 
 test('"majors" are present', async (t) => {

--- a/test/main.js
+++ b/test/main.js
@@ -3,16 +3,18 @@ import test from 'ava'
 import isPlainObj from 'is-plain-obj'
 import semver from 'semver'
 
-const isVersion = function (version) {
-  return typeof version === 'string' && VERSION_REGEXP.test(version)
+const isNodeVersion = function (nodeVersion) {
+  return typeof nodeVersion === 'string' && VERSION_REGEXP.test(nodeVersion)
 }
 
-const isNodeNpmVersion = function (nodeNpmVersion) {
+const isNpmVersion = function (npmVersion) {
+  return typeof npmVersion === 'string' && NPM_VERSION_REGEXP.test(npmVersion)
+}
+
+const isVersion = function (version) {
   return (
-    typeof nodeNpmVersion.node === 'string' &&
-    VERSION_REGEXP.test(nodeNpmVersion.node) &&
-    typeof nodeNpmVersion.npm === 'string' &&
-    NPM_VERSION_REGEXP.test(nodeNpmVersion.npm)
+    isNodeVersion(version.node) &&
+    (version.npm === undefined || isNpmVersion(version.npm))
   )
 }
 
@@ -38,27 +40,12 @@ test('"versions" are present', async (t) => {
 
 test('"versions" are sorted', async (t) => {
   const { versions } = await allNodeVersions({ fetch: true })
-  // eslint-disable-next-line fp/no-mutating-methods
-  const sortedVersions = [...versions].sort(semver.rcompare)
-
-  t.deepEqual(versions, sortedVersions)
-})
-
-test('"nodeNpmVersions" are present', async (t) => {
-  const { nodeNpmVersions } = await allNodeVersions({ fetch: true })
-
-  t.true(Array.isArray(nodeNpmVersions))
-  t.true(nodeNpmVersions.every(isNodeNpmVersion))
-})
-
-test('"nodeNpmVersions" are sorted', async (t) => {
-  const { nodeNpmVersions } = await allNodeVersions({ fetch: true })
   // eslint-disable-next-line fp/no-mutating-methods, id-length
-  const sortedVersions = [...nodeNpmVersions].sort((a, b) =>
+  const sortedVersions = [...versions].sort((a, b) =>
     semver.rcompare(a.node, b.node),
   )
 
-  t.deepEqual(nodeNpmVersions, sortedVersions)
+  t.deepEqual(versions, sortedVersions)
 })
 
 test('"majors" are present', async (t) => {
@@ -97,7 +84,7 @@ test('"majors.latest" are present', async (t) => {
 })
 
 const isValidLatest = function ({ latest }) {
-  return isVersion(latest)
+  return isNodeVersion(latest)
 }
 
 test('"majors.lts" are present', async (t) => {


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds npm versions

**List other issues or pull requests related to this problem**

Closes #8 

**Describe the solution you've chosen**

Added new "nodeNpmVersion" property to return object

**Describe alternatives you've considered**

Returning an array of npm versions and user would have to get index of node version, then check npm array for the same index, seems not very user friendly

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have added tests (we are enforcing 100% test coverage).
- [x] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
